### PR TITLE
Add Morpheus

### DIFF
--- a/ioc.yaml
+++ b/ioc.yaml
@@ -4124,3 +4124,20 @@
     - everspy.xyz
   packages:
     - app.everspy.ru
+
+- name: Morpheus
+  type: stalkerware
+  websites:
+    - www.ips-intelligence.com
+  packages:
+    - com.android.core
+    - com.android.cored
+    - com.android.corew
+  c2:
+    domains:
+    - com.android.corew
+    - gamehosts-621ba.appspot.com
+    ips:
+    - 109.239.245.172
+    - 195.120.31.91
+    - 212.210.1.211


### PR DESCRIPTION
Hi, and thanks for your work ! 

This PR adds IoC for the Morpheus spyware, all credits go to the [Osservatorio Nessuno](https://osservatorionessuno.org/) and their research on Morpheus : https://osservatorionessuno.org/blog/2026/04/morpheus-a-new-spyware-linked-to-ips-intelligence/